### PR TITLE
Alpha filtration too large

### DIFF
--- a/cechmate/filtrations/alpha.py
+++ b/cechmate/filtrations/alpha.py
@@ -6,8 +6,11 @@ import numpy.linalg as linalg
 from scipy import spatial
 
 from .base import BaseFiltration
+from .miniball import miniball_cache
+
 
 __all__ = ["Alpha"]
+
 
 class Alpha(BaseFiltration):
     """ Construct an Alpha filtration from the given data.
@@ -59,33 +62,22 @@ class Alpha(BaseFiltration):
             )
             print("Building alpha filtration...")
             tic = time.time()
-
+	
+        miniball = miniball_cache(X)
         filtration = {}
-        simplices_bydim = {}
         for dim in range(maxdim + 2, 1, -1):
-            simplices_bydim[dim] = []
             for s in range(delaunay_faces.shape[0]):
                 simplex = delaunay_faces[s, :]
                 for sigma in itertools.combinations(simplex, dim):
                     sigma = tuple(sorted(sigma))
-                    simplices_bydim[dim].append(sigma)
                     if not sigma in filtration:
-                        filtration[sigma] = self._get_circumcenter(X[sigma, :])[1]
-                    for i in range(dim):
-                        # Propagate alpha filtration value
-                        tau = sigma[0:i] + sigma[i + 1 : :]
-                        if tau in filtration:
-                            filtration[tau] = min(filtration[tau], filtration[sigma])
-                        elif len(tau) > 1:
-                            # If Tau is not empty
-                            xtau, rtauSqr = self._get_circumcenter(X[tau, :])
-                            if np.sum((X[sigma[i], :] - xtau) ** 2) < rtauSqr:
-                                filtration[tau] = filtration[sigma]
-        for f in filtration:
-            filtration[f] = np.sqrt(filtration[f])
+                        C, r2 = miniball(frozenset(sigma), frozenset([]))
+                        filtration[sigma] = np.sqrt(r2)
 
         ## Step 2: Take care of numerical artifacts that may result
         ## in simplices with greater filtration values than their co-faces
+        simplices_bydim = {dim: filter(lambda x: len(x) == dim, filtration.keys())
+                            for dim in range(maxdim + 2, 2, -1)}
         for dim in range(maxdim + 2, 2, -1):
             for sigma in simplices_bydim[dim]:
                 for i in range(dim):
@@ -106,66 +98,3 @@ class Alpha(BaseFiltration):
 
         return simplices
 
-    def _get_circumcenter(self, X):
-        """
-        Compute the circumcenter and circumradius of a simplex
-        
-        Parameters
-        ----------
-        X : ndarray (N, d)
-            Coordinates of points on an N-simplex in d dimensions
-        
-        Returns
-        -------
-        (circumcenter, circumradius)
-            A tuple of the circumcenter and squared circumradius.  
-            (SC1) If there are fewer points than the ambient dimension plus one,
-            then return the circumcenter corresponding to the smallest
-            possible squared circumradius
-            (SC2) If the points are not in general position, 
-            it returns (np.inf, np.inf)
-            (SC3) If there are more points than the ambient dimension plus one
-            it returns (np.nan, np.nan)
-        """
-        if X.shape[0] == 2:
-            # Special case of an edge, which is very simple
-            dX = X[1, :] - X[0, :]
-            rSqr = 0.25 * np.sum(dX ** 2)
-            x = X[0, :] + 0.5 * dX
-            return (x, rSqr)
-        if X.shape[0] > X.shape[1] + 1:  # SC3 (too many points)
-            warnings.warn(
-                "Trying to compute circumsphere for "
-                + "%i points in %i dimensions" % (X.shape[0], X.shape[1])
-            )
-            return (np.nan, np.nan)
-        # Transform arrays for PCA for SC1 (points in higher ambient dimension)
-        muV = np.array([])
-        V = np.array([])
-        if X.shape[0] < X.shape[1] + 1:
-            # SC1: Do PCA down to NPoints-1
-            muV = np.mean(X, 0)
-            XCenter = X - muV
-            _, V = linalg.eigh((XCenter.T).dot(XCenter))
-            V = V[:, (X.shape[1] - X.shape[0] + 1) : :]  # Put dimension NPoints-1
-            X = XCenter.dot(V)
-        muX = np.mean(X, 0)
-        D = np.ones((X.shape[0], X.shape[0] + 1))
-        # Subtract off centroid for numerical stability
-        D[:, 1:-1] = X - muX
-        D[:, 0] = np.sum(D[:, 1:-1] ** 2, 1)
-        minor = lambda A, j: A[
-            :, np.concatenate((np.arange(j), np.arange(j + 1, A.shape[1])))
-        ]
-        dxs = np.array([linalg.det(minor(D, i)) for i in range(1, D.shape[1] - 1)])
-        alpha = linalg.det(minor(D, 0))
-        if np.abs(alpha) > 0:
-            signs = (-1) ** np.arange(len(dxs))
-            x = dxs * signs / (2 * alpha) + muX  # Add back centroid
-            gamma = ((-1) ** len(dxs)) * linalg.det(minor(D, D.shape[1] - 1))
-            rSqr = (np.sum(dxs ** 2) + 4 * alpha * gamma) / (4 * alpha * alpha)
-            if V.size > 0:
-                # Transform back to ambient if SC1
-                x = x.dot(V.T) + muV
-            return (x, rSqr)
-        return (np.inf, np.inf)  # SC2 (Points not in general position)

--- a/cechmate/filtrations/alpha.py
+++ b/cechmate/filtrations/alpha.py
@@ -90,7 +90,7 @@ class Alpha(BaseFiltration):
             )
 
         simplices = [([i], 0) for i in range(X.shape[0])]
-        simplices.extend(filtration.items())
+        simplices.extend([(list(simplex), filtr) for (simplex, filtr) in filtration.items()])
 
         self.simplices_ = simplices
 

--- a/test/test_alpha.py
+++ b/test/test_alpha.py
@@ -1,0 +1,46 @@
+import time
+
+import numpy as np
+
+from cechmate import Alpha
+
+
+def test_alpha():
+
+    # Make a 3-sphere in 4 dimensions
+    X = np.random.randn(15, 4)
+    X = X / np.sqrt(np.sum(X ** 2, 1)[:, None])
+    tic = time.time()
+    diagrams = Alpha().build(X)
+    phattime = time.time() - tic
+
+
+def test_alpha_filtration_is_not_too_large():
+    # https://github.com/scikit-tda/cechmate/issues/10
+    # The points from the following test set are
+    # drawn from a standard normal 2D distribution
+    # No pair of points has a distance larger than 4
+    # Actually, the largest circumradius should be ~1.8
+    points = np.array(
+      [[ 0.01743489,  0.83907818],
+       [-0.57518843,  0.46536324],
+       [-0.19659281, -0.66731467],
+       [ 1.52911009, -0.68218385],
+       [-0.66838721, -2.21357309],
+       [ 1.14180137,  0.79701124],
+       [-0.05349503, -2.25566765],
+       [-0.27223817,  0.77621451],
+       [ 0.38597224,  1.15861246],
+       [-0.29454972,  1.71746955],
+       [-0.68879532,  1.36314908],
+       [-0.47834989, -1.57854915],
+       [ 0.94477495, -0.38586968],
+       [-0.04377718, -0.84981483],
+       [-0.03082609, -1.63861901],
+       [ 1.73579262, -0.02458939],
+       [ 0.50910058,  0.66446628],
+       [ 1.88017434,  1.66114513],
+       [ 1.47186944, -0.68486166]])
+    simplices, filtration = zip(*Alpha().build(points))
+    assert max(filtration) < 2
+

--- a/test/test_alpha.py
+++ b/test/test_alpha.py
@@ -6,13 +6,10 @@ from cechmate import Alpha
 
 
 def test_alpha():
-
     # Make a 3-sphere in 4 dimensions
     X = np.random.randn(15, 4)
     X = X / np.sqrt(np.sum(X ** 2, 1)[:, None])
-    tic = time.time()
-    diagrams = Alpha().build(X)
-    phattime = time.time() - tic
+    alpha_cplx = Alpha().build(X)
 
 
 def test_alpha_dim():

--- a/test/test_alpha.py
+++ b/test/test_alpha.py
@@ -15,6 +15,14 @@ def test_alpha():
     phattime = time.time() - tic
 
 
+def test_alpha_dim():
+    ambient_dim = 3
+    X = np.random.randn(15, ambient_dim)
+    simplices, filtration = zip(*Alpha().build(X))
+    max_simplex_dim = max(map(len, simplices)) - 1
+    assert max_simplex_dim == ambient_dim
+
+
 def test_alpha_filtration_is_not_too_large():
     # https://github.com/scikit-tda/cechmate/issues/10
     # The points from the following test set are

--- a/test/test_alpha.py
+++ b/test/test_alpha.py
@@ -20,6 +20,13 @@ def test_alpha_dim():
     assert max_simplex_dim == ambient_dim
 
 
+def test_simplex_format():
+    # Each simplex should be a list
+    X = np.random.randn(10, 2)
+    simplices, filtration = zip(*Alpha().build(X))
+    assert all(map(lambda o: isinstance(o, list), simplices))
+
+
 def test_alpha_filtration_is_not_too_large():
     # https://github.com/scikit-tda/cechmate/issues/10
     # The points from the following test set are

--- a/test/test_filtrations.py
+++ b/test/test_filtrations.py
@@ -30,12 +30,3 @@ def test_rips():
     X += 0.2 * np.random.randn(len(t), 2)
     rips = Rips(1).build(X)
 
-
-def test_alpha():
-
-    # Make a 3-sphere in 4 dimensions
-    X = np.random.randn(15, 4)
-    X = X / np.sqrt(np.sum(X ** 2, 1)[:, None])
-    tic = time.time()
-    diagrams = Alpha().build(X)
-    phattime = time.time() - tic


### PR DESCRIPTION
This should fix #10 by using the miniball algorithm and removing Alpha._get_circumsphere.
Also fixed some wording and indexing of variables around the Alpha complex.
Propose to return all simplices of an Alpha complex as lists, instead of lists for the 0-dimensional simplices and tuples for the higher dimensional simplices.
@ctralie I hope this solves the issue? I am still a bit confused because Gudhi returns the same huge filtration values (even squared) as in issue #10 . But I am quite sure this is wrong, because Alpha should be a subset of Cech, e.g. by the definition in Edelsbrunner&Harer. You might even consider adding a test for a toy example that Alpha < Cech based on just a few points.