### PR TITLE
Add weighted Delaunay triangulation

### DIFF
--- a/docs/notebooks/BasicUsage.ipynb
+++ b/docs/notebooks/BasicUsage.ipynb
@@ -332,6 +332,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Weighted Alpha filtrations\n",
+    "He we showcase an usage of Alpha filtrations when the points have some weights. \n",
+    "This is done by computing a weighted delaunay triangulation and changing the circum radius accordingly for Alpha filtratiion computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_points = 10\n",
+    "points = np.random.rand(num_points, 2)\n",
+    "weights = np.random.rand(num_points,1)\n",
+    "filtration = alpha.build(points, weights=weights)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -355,7 +376,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hey,
I added a function to compute a weighted Delaunay triangulation (to Alpha filtration) which is a really useful tool for people working with molecules and alpha complexes.
The basic idea is to compute Delaunay triangulation using its duality with convex hull of one dimension above.
I am not sure if usage of a weighted Dealunay would require a change in the circumradius computation(think not). I also added a three line example in the `BasicUsage.ipynb`.

Have a look and let me know what you think.